### PR TITLE
Update libs to support Tellor mod in UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@gnosis.pm/safe-apps-react-sdk": "3.0.0",
     "@gnosis.pm/safe-deployments": "^1.0.0",
     "@gnosis.pm/safe-react-components": "^0.6.0",
-    "@gnosis.pm/zodiac": "^1.0.10",
+    "@gnosis.pm/zodiac": "^1.0.11",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.58",
@@ -24,7 +24,7 @@
     "react-redux": "^7.2.4",
     "styled-components": "^5.1.1",
     "timeago-react": "^3.0.2",
-    "zodiac-ui-components": "^0.0.28"
+    "zodiac-ui-components": "^0.0.29"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/views/AddModule/AddModulesView.tsx
+++ b/src/views/AddModule/AddModulesView.tsx
@@ -89,33 +89,18 @@ export const AddModulesView = () => {
         </div>
 
         <ModuleButton
-          title="Tellor Module"
-          description="Enables on-chain execution of successful Snapshot proposals reported by the Tellor oracle"
-          icon="reality"
+          title="Bridge Module"
+          description="Enables an address on one chain to control an avatar on another chain using an Arbitrary Message Bridge (AMB)"
+          icon="bridge"
+          onClick={() => setModule(ModuleType.BRIDGE)}
           className={classes.firstModule}
-          onClick={() => setModule(ModuleType.TELLOR)}
         />
-
-        <ModuleButton
-          title="Reality Module"
-          description="Enables on-chain execution based on the outcome of events reported by the Reality.eth oracle"
-          icon="reality"
-          onClick={() => setModule(ModuleType.REALITY_ETH)}
-        />
-    
 
         <ModuleButton
           title="Delay Modifier"
           description="Enables a time delay between when a module initiates a transaction and when it can be executed"
           icon="delay"
           onClick={() => setModule(ModuleType.DELAY)}
-        />
-
-        <ModuleButton
-          title="Bridge Module"
-          description="Enables an address on one chain to control an avatar on another chain using an Arbitrary Message Bridge (AMB)"
-          icon="bridge"
-          onClick={() => setModule(ModuleType.BRIDGE)}
         />
 
         <ModuleButton
@@ -130,6 +115,20 @@ export const AddModulesView = () => {
           description="Allows avatars to enforce granular, role-based, permissions for attached modules"
           icon="roles"
           onClick={() => setModule(ModuleType.ROLES)}
+        />
+
+        <ModuleButton
+          title="Reality Module"
+          description="Enables on-chain execution based on the outcome of events reported by the Reality.eth oracle"
+          icon="reality"
+          onClick={() => setModule(ModuleType.REALITY_ETH)}
+        />
+
+        <ModuleButton
+          title="Tellor Module"
+          description="Enables on-chain execution of successful Snapshot proposals reported by the Tellor oracle"
+          icon="tellor"
+          onClick={() => setModule(ModuleType.TELLOR)}
         />
 
         <ModuleButton

--- a/src/views/AddModule/modals/TellorModuleModal.tsx
+++ b/src/views/AddModule/modals/TellorModuleModal.tsx
@@ -2,10 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk";
 import { Grid, makeStyles, Typography } from "@material-ui/core";
 import { AddModuleModal } from "./AddModuleModal";
-import {
-  deployTellorModule,
-  getTellorOracle,
-} from "../../../services";
+import { deployTellorModule, getTellorOracle } from "../../../services";
 import { useRootSelector } from "../../../store";
 import { AttachModuleForm } from "../AttachModuleForm";
 import { getDelayModules } from "../../../store/modules/selectors";
@@ -52,7 +49,7 @@ export const TellorModuleModal = ({
   const [params, setParams] = useState<TellorModuleParams>({
     oracle: getTellorOracle(safe.chainId),
     cooldown: "86400",
-    expiration: "604800"
+    expiration: "604800",
   });
   const [validFields, setValidFields] = useState({
     oracle: !!params.oracle,
@@ -79,13 +76,9 @@ export const TellorModuleModal = ({
     try {
       const args = {
         ...params,
-        executor: delayModule || safe.safeAddress
+        executor: delayModule || safe.safeAddress,
       };
-      const txs = deployTellorModule(
-        safe.safeAddress,
-        safe.chainId,
-        args
-      );
+      const txs = deployTellorModule(safe.safeAddress, safe.chainId, args);
 
       await sdk.txs.send({ txs });
       if (onSubmit) onSubmit();
@@ -111,7 +104,7 @@ export const TellorModuleModal = ({
       title="Tellor Module"
       description="Allows successful Snapshot proposals to 
       execute transactions using the Tellor oracle."
-      icon="reality"
+      icon="tellor"
       tags={["From Tellor"]}
       onAdd={handleAddTellorModule}
       readMoreLink="https://github.com/tellor-io/snapshot-zodiac-module"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,10 +1742,10 @@
     classnames "^2.2.6"
     react-media "^1.10.0"
 
-"@gnosis.pm/zodiac@^1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/zodiac/-/zodiac-1.0.10.tgz#8b5171c264d610a5b0668eb8585ebfd454ee9773"
-  integrity sha512-dqyqhN7Uh78wbWU/HO1GbTJC4A4/jSsrdJDPkTHyAL/5E9X+ZZ69vG0u2+8e6kcxslUGQmW7k47RnMuyRudxCw==
+"@gnosis.pm/zodiac@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/zodiac/-/zodiac-1.0.11.tgz#97032d9d8940a297ebd1a87f142565c57edfd8e4"
+  integrity sha512-J24TtMRS/5fEhFJE6BDLQu3Jjcm3u6k9KBtUSix7aidwWZzZ671RUzu+DxxZNlzA1/iuoG1uWlDCEWmxElbCEA==
   dependencies:
     "@gnosis.pm/mock-contract" "^4.0.0"
     "@gnosis.pm/safe-contracts" "1.3.0"
@@ -15383,10 +15383,10 @@ yargs@^16.1.1:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-zodiac-ui-components@^0.0.28:
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/zodiac-ui-components/-/zodiac-ui-components-0.0.28.tgz#d11dd0ab5d24770df06fe82716603d33e72e5fc8"
-  integrity sha512-fmPdrL2Ncjd7NTiKS4Z1XsuNHm3yz+1FjNLhXRpPt9+mMiYtdkKR3QBoWWpNJVVvkWsn1JUh0AuG/uEZsYbQzQ==
+zodiac-ui-components@^0.0.29:
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/zodiac-ui-components/-/zodiac-ui-components-0.0.29.tgz#85c8242d1e1012cb116efb89337b8d93beb4529f"
+  integrity sha512-aWgOXkbEq8rfryR/92AP4oRPJHM0mvkPkW39SvuGayi//I1o7zwkl7y3sXJDrCRHnuI7EKXarDouOs5lAY2oIw==
   dependencies:
     "@material-ui/icons" "^4.11.2"
     "@material-ui/lab" "^4.0.0-alpha.60"


### PR DESCRIPTION
This bumps the version of the `zodiac` and `zodiac-ui-components` libraries, which include the Tellor icon and contract addresses. I also organized the Module list alphabetically.